### PR TITLE
Fixed amigen example app link

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
 <li>Easily create a self-hosted server with command-line - <code>myapp server -p 3002</code>
 </li>
 <li>Support for easy configuration</li>
-<li>Awesomely amazing test page for your users to learn/experiment/test your API, e.g. <a href="http://services.perfectapi.com:3000/amigen/testapp/">amigen api test page</a>
+<li>Awesomely amazing test page for your users to learn/experiment/test your API, e.g. <a href="http://services.perfectapi.com/amigen/testapp/">amigen api test page</a>
 </li>
 <li>Windows and Linux installers (run your API as a true service on your server) - <code>myapp install myappservicename</code>
 </li>


### PR DESCRIPTION
The link was pointing to port 3000. Updated in this branch and main README (PR forthcoming)
